### PR TITLE
make Smime::verifyPassphrase compatibe with php8

### DIFF
--- a/lib/Horde/Crypt/Smime.php
+++ b/lib/Horde/Crypt/Smime.php
@@ -50,7 +50,7 @@ class Horde_Crypt_Smime extends Horde_Crypt
             ? openssl_pkey_get_private($private_key)
             : openssl_pkey_get_private($private_key, $passphrase);
 
-        return is_resource($res);
+        return boolval($res);
     }
 
     /**


### PR DESCRIPTION
this still works with php74, since `boolval($resource)` is always `true`